### PR TITLE
DTOer med valÃidering for null og blank værdier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/org/ek/portfoliobackend/dto/CreateProjectRequest.java
+++ b/src/main/java/org/ek/portfoliobackend/dto/CreateProjectRequest.java
@@ -1,0 +1,77 @@
+package org.ek.portfoliobackend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public class CreateProjectRequest {
+
+    @NotBlank(message = "The project requires a title")
+    private String title;
+
+    @NotBlank(message = "The project requires a description")
+    private String description;
+
+    @NotNull(message = "The project requires an execution date")
+    private LocalDate executionDate;
+
+    @NotNull(message = "The project requires a service category")
+    private ServiceCategory serviceCategory;
+
+    @NotNull(message = "The project requires a customer type")
+    private CustomerType customerType;
+
+    public CreateProjectRequest() {}
+
+    public CreateProjectRequest(String title, String description, LocalDate executionDate,
+                                ServiceCategory serviceCategory, CustomerType customerType) {
+        this.title = title;
+        this.description = description;
+        this.executionDate = executionDate;
+        this.serviceCategory = serviceCategory;
+        this.customerType = customerType;
+    }
+
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDate getExecutionDate() {
+        return executionDate;
+    }
+
+    public void setExecutionDate(LocalDate executionDate) {
+        this.executionDate = executionDate;
+    }
+
+    public ServiceCategory getServiceCategory() {
+        return serviceCategory;
+    }
+
+    public void setServiceCategory(ServiceCategory serviceCategory) {
+        this.serviceCategory = serviceCategory;
+    }
+
+    public CustomerType getCustomerType() {
+        return customerType;
+    }
+
+    public void setCustomerType(CustomerType customerType) {
+        this.customerType = customerType;
+    }
+}
+

--- a/src/main/java/org/ek/portfoliobackend/dto/ImageUploadRequest.java
+++ b/src/main/java/org/ek/portfoliobackend/dto/ImageUploadRequest.java
@@ -1,0 +1,36 @@
+package org.ek.portfoliobackend.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+public class ImageUploadRequest {
+
+    @NotNull(message = "The image requires an image type")
+    private ImageType imageType;
+
+    @JsonProperty(defaultValue = "false") // Bliver false i backend, hvis brugeren ikke angiver værdien
+    private Boolean isFeatured;
+
+    public ImageUploadRequest() {}
+
+    public ImageUploadRequest(ImageType imageType, boolean isFeatured) {
+        this.imageType = imageType;
+        this.isFeatured = isFeatured;
+    }
+
+    public ImageType getImageType() {
+        return imageType;
+    }
+
+    public void setImageType(ImageType imageType) {
+        this.imageType = imageType;
+    }
+
+    public boolean isFeatured() {
+        return isFeatured;
+    }
+
+    public void setFeatured(boolean featured) {
+        isFeatured = featured;
+    }
+}


### PR DESCRIPTION
## Description
DTO'erne validerer felterne lige nu som teknisk accept-kriterium foreskriver. Ved ikke om det er det bedste sted, at gøre det, men måske meget rart at få blokerede null/blank input allerede ved requests for at sikre db-persistens.

## Related Issue
Closes #53 

## Type of Change
<!-- Mark with an "x" -->
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring

## Changes Made
<!-- List the specific changes -->
- 
- 
- 

## Testing
<!-- Describe the testing performed -->
- [ ] Manual testing completed
- [ ] Tests added/updated (if applicable)
- [ ] All tests pass locally

## Screenshots/Videos
<!-- If applicable, add screenshots or videos -->

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Ready for code review

## Additional Notes
<!-- Any additional context or notes for reviewers -->
